### PR TITLE
Fixing $rdf undefined during webpack build

### DIFF
--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1153,7 +1153,7 @@ class Fetcher {
     function fetchAclDoc(url,there){
      return new Promise(function(resolve, reject){
       ft.load(url).then( response => {
-        let aclRel = $rdf.sym(
+        let aclRel = st.sym(
             'http://www.iana.org/assignments/link-relations/acl'
         )
         let aclDoc = st.any(url,aclRel)


### PR DESCRIPTION
@jeff-zucker please correct me if I am wrong but isn't the line should be replaced to `st.sym()` from`$rdf.sym()` ?

I had webpack crashing on `$rdf undefined` when I tried to run the recursiveCopy on rdflib from fork of your repository inside my project. Changing that line from `$rdf.sym()` to `st.sym()` fixed the issue for me.